### PR TITLE
Updating with information about GCP Artifact Registry

### DIFF
--- a/content/ecosystem/platform-tooling/image-registries/_index.md
+++ b/content/ecosystem/platform-tooling/image-registries/_index.md
@@ -13,5 +13,6 @@ _Internal Developer Platforms (IDPs) are a new category of tools. This means, th
 [Amazon Elastic Container Registry (ECR)]({{< relref "amazon-ecr" >}}) |
 [Azure Container Registry]({{< relref "azure-container-registry" >}}) |
 [DockerHub]({{< relref "dockerhub" >}}) |
+[Artifact Registry \| Google Cloud]({{< relref "gcp-artifact-registry" >}}) |
 [Container Registry \| Google Cloud]({{< relref "gcp-container-registry" >}}) |
 [Harbor]({{< relref "harbor" >}}) |

--- a/content/ecosystem/platform-tooling/image-registries/gcp-artifact-registry.md
+++ b/content/ecosystem/platform-tooling/image-registries/gcp-artifact-registry.md
@@ -1,0 +1,12 @@
++++
+title="GCP Artifact Registry"
+url="/registries/google-artifact-registry"
++++
+
+# Artifact Registry \| Google Cloud
+
+As the evolution of Container Registry, Artifact Registry is a single place for your organization to manage container images and language packages (such as Maven and npm). It is fully integrated with Google Cloud’s tooling and runtimes and comes with support for native artifact protocols. This makes it simple to integrate it with your CI/CD tooling to set up automated pipelines.
+
+{{< button href="https://cloud.google.com/artifact-registry" target="_blank" >}}
+-> Artifact Registry by Google Cloud
+{{< /button >}}

--- a/content/ecosystem/platform-tooling/image-registries/gcp-container-registry.md
+++ b/content/ecosystem/platform-tooling/image-registries/gcp-container-registry.md
@@ -7,6 +7,8 @@ url="/registries/google-container-registry"
 
 Container Registry is a single place for your team to manage Docker images, perform vulnerability analysis, and decide who can access what with fine-grained access control. Existing Continuous Integration, Continous Delivery, and Deployment (referred to as CI/CD) integrations let you set up fully automated Docker pipelines to get fast feedback.
 
+***NOTE : Container Registry is still available and will continue to be supported as a [Google Enterprise API](https://cloud.google.com/blog/topics/inside-google-cloud/new-api-stability-tenets-govern-google-enterprise-apis), going forward new features will only be available in Artifact Registry, and Container Registry will only receive critical security fixes.***
+
 {{< button href="https://cloud.google.com/container-registry" target="_blank" >}}
 -> Container Registry by Google Cloud
 {{< /button >}}


### PR DESCRIPTION
Added a section for GCP Artifact Registry to the Image Registries section as the GCP Container Registry is no longer getting new features etc. and the recommendation from GCP is to use Artifact Registry.