### PR TITLE
docs: add bytebase to CI Tools

### DIFF
--- a/content/ecosystem/platform-tooling/ci-tools/_index.md
+++ b/content/ecosystem/platform-tooling/ci-tools/_index.md
@@ -10,6 +10,7 @@ _Internal Developer Platforms (IDPs) are the sum of all tools and tech that plat
 
 **Integration** |
 --- |
+[Bytebase]({{< relref "bytebase" >}}) |
 [CircleCI]({{< relref "circleci" >}}) |
 [Codefresh]({{< relref "codefresh" >}}) |
 [GitHub Actions]({{< relref "github-actions" >}}) |

--- a/content/ecosystem/platform-tooling/ci-tools/bytebase.md
+++ b/content/ecosystem/platform-tooling/ci-tools/bytebase.md
@@ -1,0 +1,12 @@
++++
+title="Bytebase"
+url="/ci-tools/bytebase"
++++
+
+# Bytebase
+
+Bytebase is an open source database CI/CD tool for developers and DBAs. It covers the entire database development lifecyle including database change and query, SQL review, version control and rollback. Bytebase supports MySQL, PostgreSQL, TiDB, ClickHouse and Snowflake. It also provides GitOps workflow with the native GitLab and GitHub integration.
+
+{{< button href="https://www.bytebase.com/" target="_blank" >}}
+-> Bytebase
+{{< /button >}}


### PR DESCRIPTION
[Bytebase](www.bytebase.com) is an open source database CI/CD tool for developers and DBAs.

It's also included in the CNCF CI/CD landscape https://landscape.cncf.io/?selected=bytebase