### PR TITLE
Add Giant Swarm to the list

### DIFF
--- a/content/ecosystem/paas-devops-platforms/_index.md
+++ b/content/ecosystem/paas-devops-platforms/_index.md
@@ -16,7 +16,7 @@ If you don't want to build an IDP on your own, if you don't have the capacity to
 | --------------------------------------------- |
 | [Coherence]({{< relref "coherence" >}})       |
 | [DevOpsBox]({{< relref "devopsbox" >}})       |
-| [Giant Swarm]({{< relref "giantswarm" >}})    |
 | [dyrector.io]({{< relref "dyrectorio" >}})    |
+| [Giant Swarm]({{< relref "giantswarm" >}})    |
 | [Mia-Platform]({{< relref "mia-platform" >}}) |
 | [Portainer]({{< relref "portainer-ce" >}})    |

--- a/content/ecosystem/paas-devops-platforms/_index.md
+++ b/content/ecosystem/paas-devops-platforms/_index.md
@@ -14,9 +14,9 @@ If you don't want to build an IDP on your own, if you don't have the capacity to
 
 | **PaaS and end-to-end DevOps Platforms**      |
 | --------------------------------------------- |
+| [Coherence]({{< relref "coherence" >}})       |
 | [DevOpsBox]({{< relref "devopsbox" >}})       |
+| [Giant Swarm]({{< relref "giantswarm" >}})    |
 | [dyrector.io]({{< relref "dyrectorio" >}})    |
 | [Mia-Platform]({{< relref "mia-platform" >}}) |
 | [Portainer]({{< relref "portainer-ce" >}})    |
-| [Coherence]({{< relref "coherence" >}})       |
-| [Giant Swarm]({{< relref "giantswarm" >}})    |

--- a/content/ecosystem/paas-devops-platforms/_index.md
+++ b/content/ecosystem/paas-devops-platforms/_index.md
@@ -19,3 +19,4 @@ If you don't want to build an IDP on your own, if you don't have the capacity to
 | [Mia-Platform]({{< relref "mia-platform" >}}) |
 | [Portainer]({{< relref "portainer-ce" >}})    |
 | [Coherence]({{< relref "coherence" >}})       |
+| [Giant Swarm]({{< relref "giantswarm" >}})    |

--- a/content/ecosystem/paas-devops-platforms/giantswarm.md
+++ b/content/ecosystem/paas-devops-platforms/giantswarm.md
@@ -1,0 +1,28 @@
++++
+title="Giant Swarm"
+aliases="/frameworks/giantswarm/"
+url="/paas-devops-platforms/giantswarm"
++++
+
+# Coherence
+
+**Claim:** 
+Giant Swarm’s Cloud Native Platform enables teams to rapidly develop, iterate and operate services at scale.
+
+
+**What Giant Swarm is:**
+
+*Giant Swarm is a product.* It’s built incrementally by incorporating feedback from all our customers. It accelerates the delivery of products.
+
+*Differentiating.* It empowers your teams to concentrate on solving real business problems by abstracting away organisational complexities and toil.
+
+*Opinionated.* It makes it easy for your teams to build, deploy, and operate products by providing a curated set of high quality building blocks.
+
+
+**Website:**[www.giantswarm.io](https://www.giantswarm.io/)
+
+**Docs:** [docs.giantswarm.io](https://docs.giantswarm.io/)
+
+{{< button href="https://github.com/giantswarm" target="_blank" >}}
+-> Giant Swarm GitHub repository
+{{< /button >}}

--- a/content/ecosystem/paas-devops-platforms/giantswarm.md
+++ b/content/ecosystem/paas-devops-platforms/giantswarm.md
@@ -12,11 +12,11 @@ Giant Swarm’s Cloud Native Platform enables teams to rapidly develop, iterate 
 
 **What Giant Swarm is:**
 
-*Giant Swarm is a product.* It’s built incrementally by incorporating feedback from all our customers. It accelerates the delivery of products.
+*Giant Swarm is a Kubernetes-based product.* It’s built incrementally by incorporating feedback from all our customers. It accelerates the delivery of products.
 
 *Differentiating.* It empowers your teams to concentrate on solving real business problems by abstracting away organisational complexities and toil.
 
-*Opinionated.* It makes it easy for your teams to build, deploy, and operate products by providing a curated set of high quality building blocks.
+*Opinionated.* It makes it easy for your teams to build, deploy, and operate products by providing a curated set of high quality platform building blocks.
 
 
 **Website:**[www.giantswarm.io](https://www.giantswarm.io/)


### PR DESCRIPTION
This PR adds Giant Swarm to the list of PaaS and DevOps Platforms.