### PR TITLE
Add Zalando Postgres operator to platform tooling/databases/postgresql

### DIFF
--- a/content/ecosystem/platform-tooling/databases/postgresql.md
+++ b/content/ecosystem/platform-tooling/databases/postgresql.md
@@ -10,3 +10,9 @@ PostgreSQL is a powerful, open source object-relational database system with ove
 {{< button href="https://www.postgresql.org/" target="_blank" >}}
 -> PostgreSQL
 {{< /button >}}  
+
+### PostgreSQL Kubernetes scalable solution
+
+[Postgres operator](https://postgres-operator.readthedocs.io/en/latest/) is a scalable solution that enables teams to create, update, upgrade and monitor PostgreSQL clusters using Kubernetes CRDs.
+
+It is actively maintained and battle tested by [Zalando](https://engineering.zalando.com/).


### PR DESCRIPTION
Postgres operator is used within Zalando to enable 200+ teams to deploy a scalable PostgreSQL cluster effortlessly.

https://postgres-operator.readthedocs.io/en/latest/