### PR TITLE
Fix blog link of expert James Whinn

### DIFF
--- a/content/community/experts/james_whinn.md
+++ b/content/community/experts/james_whinn.md
@@ -9,4 +9,4 @@ url="/experts/james_whinn"
 
 As an advocate of Internal Developer Platforms, James believes that IDP's are key to an organisations ability to compete in the age of software. James goes further to suggest that often, in times where companies across all sectors are increasingly adapting to become technology companies, that the difference between success or falling behind the competion is often the successful adoption of an IDP which enables the organisation to deliver on its business outcomes. 
 
-Follow James and his team on the Expert Thinking [blog](https://expert-thinking.co.uk/our-blog/) and also connect with him via [Linkedin](https://www.linkedin.com/in/jameswhinn/)
+Follow James and his team on the Expert Thinking [blog](https://expert-thinking.co.uk/expert-blog/) and also connect with him via [Linkedin](https://www.linkedin.com/in/jameswhinn/)


### PR DESCRIPTION
I guess since the [James Whinns blog](https://expert-thinking.co.uk/our-blog/)
results in a 404, the correct blog is [expert-blog](https://expert-thinking.co.uk/expert-blog/).
