### PR TITLE
Add Qovery as a PaaS DevOps Platform

### DIFF
--- a/content/ecosystem/paas-devops-platforms/_index.md
+++ b/content/ecosystem/paas-devops-platforms/_index.md
@@ -21,3 +21,4 @@ If you don't want to build an IDP on your own, if you don't have the capacity to
 | [gopaddle]({{< relref "gopaddle" >}})         |
 | [Mia-Platform]({{< relref "mia-platform" >}}) |
 | [Portainer]({{< relref "portainer-ce" >}})    |
+| [Qovery]({{< relref "qovery" >}})             |

--- a/content/ecosystem/paas-devops-platforms/qovery.md
+++ b/content/ecosystem/paas-devops-platforms/qovery.md
@@ -1,0 +1,24 @@
++++
+title="Qovery"
+aliases="/frameworks/qovery/"
+url="/paas-devops-platforms/qovery"
++++
+
+# Qovery
+
+**Claim:** The self-service infrastructure platform with an outstanding developer experience
+
+**Focus:** Qoveru is a full-cycle platform that enables development, testing, and deployment of full-stack web apps, supporting and formalizing the full SDLC. Includes functionality to manage databases and other cloud resources in all environment types (dev/Cloud IDE, staging/ephemeral branch previews, & production).
+
+**Website:**[www.qovery.com](https://www.qovery.com/)
+
+**Docs:** [hub.qovery.com](https://hub.qovery.com/)
+
+**Blog:**[blog.qovery.com](https://www.qovery.com/blog)
+
+**Forum:** [discuss.qovery.com](https://discuss.qovery.com/)
+
+{{< button href="https://www.qovery.com" target="_blank" >}}
+-> Qovery
+{{< /button >}}  
+


### PR DESCRIPTION
Hi, here is a PR to add Qovery as a PaaS DevOps Platform. Let me know if I need to change something. Thank you.