### PR TITLE
Add Cloudraft in Consultancies

### DIFF
--- a/content/community/consultancies/_index.md
+++ b/content/community/consultancies/_index.md
@@ -11,16 +11,17 @@ _Internal Developer Platforms (IDPs) are a new category of tools. This means, th
 
 There are a number of great DevOps consultancies out there that can help you to build your own Internal Developer Platform (IDP). We will enhance this section step by step.
 
-**Consultancy** |
---- |
-[axem]({{< relref "axem" >}}) |
-[Codecentric]({{< relref "codecentric" >}}) |
-[Container Solutions]({{< relref "container-solutions" >}}) |
-[Eficode]({{< relref "eficode" >}}) |
-[EqualExperts]({{< relref "equalexperts" >}}) |
-[Expert Thinking]({{< relref "expert-thinking" >}}) |
-[Hallatek]({{< relref "hallatek" >}}) |
-[Platform Engineers]({{< relref "platform-engineers-io" >}}) |
-[Polarsquad]({{< relref "polarsquad" >}}) |
-[Tektit Consulting]({{< relref "tektit" >}}) |
-[Thoughtworks]({{< relref "thoughtworks" >}}) |
+| **Consultancy**                                              |
+| ------------------------------------------------------------ |
+| [axem]({{< relref "axem" >}})                                |
+| [Cloudraft]({{< relref "cloudraft" >}})                      |
+| [Codecentric]({{< relref "codecentric" >}})                  |
+| [Container Solutions]({{< relref "container-solutions" >}})  |
+| [Eficode]({{< relref "eficode" >}})                          |
+| [EqualExperts]({{< relref "equalexperts" >}})                |
+| [Expert Thinking]({{< relref "expert-thinking" >}})          |
+| [Hallatek]({{< relref "hallatek" >}})                        |
+| [Platform Engineers]({{< relref "platform-engineers-io" >}}) |
+| [Polarsquad]({{< relref "polarsquad" >}})                    |
+| [Tektit Consulting]({{< relref "tektit" >}})                 |
+| [Thoughtworks]({{< relref "thoughtworks" >}})                |

--- a/content/community/consultancies/cloudraft.md
+++ b/content/community/consultancies/cloudraft.md
@@ -1,0 +1,17 @@
+
++++
+title="Cloudraft"
+url="/consultancies/cloudraft"
++++
+
+# Cloudraft
+
+Cloudraft is a DevOps & Platform Engineering Consulting company. We make developers happy by leveraging cloud-native solutions and reducing friction by implementing automation and setting up an easy-to-use platform using Cloud and Kubernetes. We have served early-stage companies to scale-ups. 
+
+## Blog
+
+Check out our [blog](https://cloudraft.io/blog) to learn more about us!
+
+{{< button href="https://cloudraft.io/" target="_blank" >}}
+-> Cloudraft
+{{< /button >}}  


### PR DESCRIPTION
Cloudraft is a consulting company specializing in DevOps & Platform Engineering space. Please add it to the list.
I am the owner of the business.