### PR TITLE
Platform.sh

### DIFF
--- a/content/ecosystem/paas-devops-platforms/_index.md
+++ b/content/ecosystem/paas-devops-platforms/_index.md
@@ -22,4 +22,5 @@ If you don't want to build an IDP on your own, if you don't have the capacity to
 | [Mia-Platform]({{< relref "mia-platform" >}}) |
 | [Nullstone]({{< relref "nullstone" >}})       |
 | [Portainer]({{< relref "portainer-ce" >}})    |
+| [Platform.sh]({{< relref "platformsh" >}})    |
 | [Qovery]({{< relref "qovery" >}})             |

--- a/content/ecosystem/paas-devops-platforms/platformsh.md
+++ b/content/ecosystem/paas-devops-platforms/platformsh.md
@@ -12,7 +12,7 @@ Platform.sh is a polyglot, multi-cloud PaaS for all types of composable web proj
 
 As an End-to-End service, Platform.sh takes care of the entire Build, Test & Deploy cycle, adding layers of security and certifications, access control and team management, observability and continuous performance monitoring using <a href="https://blackfire.io" target="_blank">Blackfire.io</a>.
 
-Platform.sh considers the reduction of its environmental impact as one of its top values. We use a unique technology to be able to increase the applications density on our servers for maximum utilisation of the running hardware. In addition, users are presented with the energy impact of each data center, so they can make a learned decision when choosing their deploy target.
+Platform.sh considers the reduction of its environmental impact as one of its top values. We use a unique technology to be able to increase the applications density on our servers for maximum utilisation of the running hardware. In addition, users are presented with the energy impact of each data center, so they can make a learned decision when choosing their deployment target.
 
 
 **Website:** [Platform.sh](https://platform.sh/)
@@ -44,13 +44,13 @@ Developers and platform engineers configure their web projects in a simple Yaml 
 
 Further interaction with the platform is possible through any of the following methods:
 
-- **Git**: Most of the interaction with the platform is done using Git commands, so the Build, Test & Deploy process is seamlessly integrated into the usual workflow of the developer, whatever it is (we don't force any git workflow).<br />On each `git push` event, a build and deploy are triggered. Developers can create new Preview Environment by simply creating and pushing a new branch.
-- **CLI / API**: All the operations and interactiosns of the developer with the platform are available as API requests and with the CLI that comes with it. This allows a very high level of automation. Leveraging the API, some organizations are using Platform.sh as a white-label PaaS, proposing their users and clients a unique and custom experience and workflow.
+- **Git**: Most of the interaction with the platform is done using Git commands, so the Build, Test & Deploy process is seamlessly integrated into the usual workflow of the developer, whatever it is (we don't force any git workflow).<br />On each `git push` event, a build and deploy are triggered. Developers can create new Preview Environments by simply creating and pushing a new branch.
+- **CLI / API**: All the operations and interactions of the developer with the platform are available as API requests and with the CLI that comes with it. This allows a very high level of automation. Leveraging the API, some organizations are using Platform.sh as a white-label PaaS, proposing their users and clients a unique and custom experience and workflow.
 - **Web console**: Eventually, most operations are also available through the web console in which the developers can also monitor their application performance and logs.
 
 ### Local development
 
-Platform.sh is the lead sponsor of [DDEV](https://ddev.com/blog/platform-sh-becomes-a-lead-sponsor-of-ddev/), a Docker based local development tool, which has an excellet integration with Platform.sh, allowing easy cloning and syncing environments in both ways, and gives you the closest experience to production-like environment on your local machine. 
+Platform.sh is the lead sponsor of [DDEV](https://ddev.com/blog/platform-sh-becomes-a-lead-sponsor-of-ddev/), a Docker based local development tool, which has an excellent integration with Platform.sh, allowing easy cloning and syncing environments in both ways, and gives you the closest experience to a production-like environment on your local machine. 
 
 ### Observability Suite
 
@@ -63,7 +63,7 @@ Platform.sh has a pricing model to any size of company, from the single develope
 Our SLA is suitable for business-critical projects on either shared or dedicated resources.
 
 
-## Numerous Runtimes and intagrations
+## Numerous Runtimes and integrations
 
 Platform.sh supports almost any possible language you may need to run your project:
 - C#/.NET Core

--- a/content/ecosystem/paas-devops-platforms/platformsh.md
+++ b/content/ecosystem/paas-devops-platforms/platformsh.md
@@ -1,0 +1,102 @@
++++
+title="Platform.sh"
+aliases="/frameworks/platform-sh/"
+url="/paas-devops-platforms/platform-sh"
++++
+
+# Platform.sh
+
+**Responsible and scalable application delivery platform**
+
+Platform.sh is a polyglot, multi-cloud PaaS for all types of composable web projects (from monoliths to microservices and mixed-technologies web applications).
+
+As an End-to-End service, Platform.sh takes care of the entire Build, Test & Deploy cycle, adding layers of security and certifications, access control and team management, observability and continuous performance monitoring using <a href="https://blackfire.io" target="_blank">Blackfire.io</a>.
+
+Platform.sh considers the reduction of its environmental impact as one of its top values. We use a unique technology to be able to increase the applications density on our servers for maximum utilisation of the running hardware. In addition, users are presented with the energy impact of each data center, so they can make a learned decision when choosing their deploy target.
+
+
+**Website:** [Platform.sh](https://platform.sh/)
+
+**Docs:** [https://docs.platform.sh](https://docs.platform.sh)
+
+**Github:** [https://github.com/platformsh](https://github.com/platformsh)
+
+**X / Twitter:** [https://twitter.com/platformsh](https://twitter.com/platformsh)
+
+{{< button href="https://console.platform.sh/projects/create-project" target="_blank" >}}
+Start a new project
+{{< /button >}}
+{{< button href="https://github.com/platformsh-templates" target="_blank" >}}
+Check out our Deploy Templates on Github
+{{< /button >}}
+
+
+## Who is it for?
+
+- **Hybrid Development teams:** Platform.sh is built for web agencies and software vendors (ISVs) who deploy many projects by many developers, both internal and external. We have a granular access management control which allows the project owner to determine exactly who has access to manage or contribute to a project.
+- **Software vendors with a SaaS/PaaS strategy:** Platform.sh is **built for White-label**, meaning that ISVs can build their own branded cloud solution on Platform.sh, whether it's a SaaS solution or a PaaS solution, whether it's for internal use or client-facing. Numerous PaaS solutions out there actually use Platform.sh as their backend. Our white label includes not only the web console but also the CLI. Check out <a href="https://symfony.com/" target="_blank">Symfony</a> Cloud for example.
+- **Organizations seeking high standards and compliances**: Platform.sh enables the deployment of many different types of applications all under the same hood and the same standards and workflows, with the back of high level security and privacy compliances.
+
+
+## Developer and DevOps Experience
+
+Developers and platform engineers configure their web projects in a simple Yaml file. 
+
+Further interaction with the platform is possible through any of the following methods:
+
+- **Git**: Most of the interaction with the platform is done using Git commands, so the Build, Test & Deploy process is seamlessly integrated into the usual workflow of the developer, whatever it is (we don't force any git workflow).<br />On each `git push` event, a build and deploy are triggered. Developers can create new Preview Environment by simply creating and pushing a new branch.
+- **CLI / API**: All the operations and interactiosns of the developer with the platform are available as API requests and with the CLI that comes with it. This allows a very high level of automation. Leveraging the API, some organizations are using Platform.sh as a white-label PaaS, proposing their users and clients a unique and custom experience and workflow.
+- **Web console**: Eventually, most operations are also available through the web console in which the developers can also monitor their application performance and logs.
+
+### Local development
+
+Platform.sh is the lead sponsor of [DDEV](https://ddev.com/blog/platform-sh-becomes-a-lead-sponsor-of-ddev/), a Docker based local development tool, which has an excellet integration with Platform.sh, allowing easy cloning and syncing environments in both ways, and gives you the closest experience to production-like environment on your local machine. 
+
+### Observability Suite
+
+Platform.sh has the most advanced [Observability Suite](https://platform.sh/features/observability-suite/) with everything developers as well as platform engineers and Devops require to constantly improve their application's performance, identify issues and bugs before they reach production, and constantly monitor the application for degraded performance.
+
+
+## Flexible plans and pricing
+
+Platform.sh has a pricing model to any size of company, from the single developer looking for a pay-as-you-go and pay-as-you-grow model, to predictable fixed pricing for big enterprises. 
+Our SLA is suitable for business-critical projects on either shared or dedicated resources.
+
+
+## Numerous Runtimes and intagrations
+
+Platform.sh supports almost any possible language you may need to run your project:
+- C#/.NET Core
+- Elixir
+- Go
+- Java
+- JavaScript/Node.js
+- Lisp
+- PHP
+- Python
+- Ruby
+- Rust
+
+In addition, to make life even easier for any developer, we offer the following integrations and managed services:
+- Elasticsearch Premium
+- Headless Chrome
+- InfluxDB
+- Kafka
+- MariaDB/MySQL
+- Memcached
+- MongoDB Premium
+- Network Storage
+- OpenSearch
+- PostgreSQL
+- RabbitMQ
+- Redis
+- Solr
+- Varnish
+- Vault KMS
+
+{{< button href="https://console.platform.sh/projects/create-project" target="_blank" >}}
+Start a new project
+{{< /button >}}
+{{< button href="https://github.com/platformsh-templates" target="_blank" >}}
+Check out our Deploy Templates on Github
+{{< /button >}}


### PR DESCRIPTION
I added a page for Platform.sh under the **PaaS and DevOps Platforms** section. 
Platform.sh is a hosted development portal which can be used both internally (for in-house development and access) as well as externally (client facing).