### PR TITLE
Add Charmed Kubernetes to self-hosted K8s options

### DIFF
--- a/content/ecosystem/platform-tooling/kubernetes/kubernetes-self-hosted/_index.md
+++ b/content/ecosystem/platform-tooling/kubernetes/kubernetes-self-hosted/_index.md
@@ -9,8 +9,8 @@ weight=10
 
 _Internal Developer Platforms (IDPs) are a new category of tools. This means, the sector is still emerging. Are we missing any integrations? [Submit a pull request!]({{< relref "/#how-to-contribute-to-internal-developer-platform" >}})_
 
-**Integration** |
---- |
-[OpenShift]({{< relref "openshift" >}}) |
-[Rancher]({{< relref "rancher" >}}) |
-[Charmed Kubernetes]({{< relref "charmed-k8s" >}}) |
+| **Integration**                                    |
+| -------------------------------------------------- |
+| [Charmed Kubernetes]({{< relref "charmed-k8s" >}}) |
+| [OpenShift]({{< relref "openshift" >}})            |
+| [Rancher]({{< relref "rancher" >}})                |

--- a/content/ecosystem/platform-tooling/kubernetes/kubernetes-self-hosted/_index.md
+++ b/content/ecosystem/platform-tooling/kubernetes/kubernetes-self-hosted/_index.md
@@ -13,3 +13,4 @@ _Internal Developer Platforms (IDPs) are a new category of tools. This means, th
 --- |
 [OpenShift]({{< relref "openshift" >}}) |
 [Rancher]({{< relref "rancher" >}}) |
+[Charmed Kubernetes]({{< relref "charmed-k8s" >}}) |

--- a/content/ecosystem/platform-tooling/kubernetes/kubernetes-self-hosted/charmed-k8s.md
+++ b/content/ecosystem/platform-tooling/kubernetes/kubernetes-self-hosted/charmed-k8s.md
@@ -1,0 +1,32 @@
++++
+title="Charmed Kubernetes"
+url="/self-hosted-kubernetes/charmed-k8s"
++++
+
+# Charmed Kubernetes
+
+Charmed K8s is a CNCF-certified, turnkey Kubernetes distribution. It claims
+to provide architectural freedom and fully automated operations.
+
+Charmed K8s is installed and managed by Juju, an open source orchestration
+engine for software operators developed by Canonical that enables deployment,
+integration and lifecycle management of applications at scale. The components
+managed by Juju are called Charms. They are independent, composable deployments
+of applications that can be related to each other, conveniently.
+
+Charmed K8s is deployed with a high availability setup by default, it runs
+automatic updates and security fixes for all core Kubernetes components, has
+full OCI compatability with Docker and containderd runtimes, performs PCI
+device passthrough for GPU, FPGA and SR-IOV workloads, can manage VMs on
+Kubernetes with Kata containers, and is backed by an extensible, third-party
+ecosystem for storage and networking.
+
+Charmed K8s runs on bare metal, private clouds, public clouds, and hybrid
+clouds. That said, the same Kubernetes distribution runs on various platforms
+and flavors of infrastructure (Juju calls them "substrates"). This allows
+application infrastructure owners to move between offerings and optimize
+cost, performance, stability and availability concerns.
+
+{{< button href="https://ubuntu.com/kubernetes/charmed-k8s" target="_blank" >}}
+-> Charmed Kubernetes
+{{< /button >}}


### PR DESCRIPTION
Adds Canonical's Charmed K8s Kubernetes distribution to the [self-hosted Kubernetes](https://internaldeveloperplatform.org/self-hosted-kubernetes/) section.

Parts of the content is taken from or inspired by Canonical's [Ubuntu website](https://ubuntu.com/), though reworded or entirely phrased anew.

I'm not affiliated to Canonical or any of its vendors (if any such exist).