### PR TITLE
Add Dynatrace to list of monitoring platforms

### DIFF
--- a/content/ecosystem/platform-tooling/monitoring/_index.md
+++ b/content/ecosystem/platform-tooling/monitoring/_index.md
@@ -11,6 +11,7 @@ _Internal Developer Platforms (IDPs) are a new category of tools. This means, th
 | **Integration**                           |
 | ----------------------------------------- |
 | [Datadog]({{< relref "datadog" >}})       |
+| [Dynatrace]({{< relref "dynatrace" >}})   |
 | [Elastic]({{< relref "elastic" >}})       |
 | [Grafana]({{< relref "grafana" >}})       |
 | [Instana]({{< relref "instana" >}})       |

--- a/content/ecosystem/platform-tooling/monitoring/dynatrace.md
+++ b/content/ecosystem/platform-tooling/monitoring/dynatrace.md
@@ -1,0 +1,29 @@
++++
+title="Dynatrace"
+url="/monitoring/dynatrace"
++++
+
+# Dynatrace
+
+Dynatrace is a cloud-based monitoring service providing unified observability,
+application security and infrastructure monitoring. It is similar to New Relic
+and Datadog, though, it provides low-configuration or configuration-less
+integration of the services to monitor, as a core differentiator.
+
+On Kubernetes platforms, the Dynatrace instrumentation is injected in workloads
+without any need for configuration. While this is convenient, it can have
+undesirable side-effects, sometimes, causing operational instability of
+services based on certain technology stacks.
+
+Davis AI is a component that claims to automatically draw conclusions on the
+root cause of detected operational problems. PurePath is what Dynatrace calls
+its tracing and code-level analysis technology, which allows to analyse where
+applications spend most of their time, to identify performance bottlenecks and
+improvement areas across the entire application stack.
+
+Dynatrace positions itself also as an automation platform, combining the
+aspects of service deployment and service monitoring.
+
+{{< button href="https://www.dynatrace.com/" target="_blank" >}}
+-> Dynatrace
+{{< /button >}}


### PR DESCRIPTION
Dynatrace is a monitoring platform available in the cloud and as an on-premise installation, which seems to have gained significant popularity in larger organizations, in the last few years.

I'm not affiliated to Dynatrace or any of its vendors (if any such exist). I have hands-on experience with the product (and their engineering workforce) from a few places of work, though.