### PR TITLE
Add Rely.io to developer portals

### DIFF
--- a/content/ecosystem/platform-tooling/developer-portals/_index.md
+++ b/content/ecosystem/platform-tooling/developer-portals/_index.md
@@ -27,4 +27,5 @@ https://www.gartner.com/document/4017457
 | [Flanksource Mission Control]({{< relref "flanksource-mission-control" >}}) | Kubernetes-native Internal Developer Portal and GitOps orchestrator. |
 | [OpsLevel]({{< relref "opslevel" >}})                                       | All your services, all in one interface                              |
 | [Port]({{< relref "port" >}})                                               | A developer portal for all your services,software & resources        |
+| [Rely.io]({{< relref "relyio" >}})                                          | A Managed Developer experience that just works                       |
 | [Roadie]({{< relref "roadie" >}})                                           | Backstage as a service: adopt OSS without the overhead               |

--- a/content/ecosystem/platform-tooling/developer-portals/relyio.md
+++ b/content/ecosystem/platform-tooling/developer-portals/relyio.md
@@ -1,0 +1,68 @@
++++
+title="Rely.io"
+aliases="/frameworks/relyio"
+url="/developer-portals/relyio"
++++
+
+# Rely.io
+
+**Claim**: A Managed Developer experience that just works.
+
+**Focus**: Rely.io is an Internal Developer Portal that grants developers autonomy, reduces costs and increases productivity all while ensuring governance and standardization.
+
+**Website**: [rely.io](https://rely.io/)
+
+**Docs**: [docs.rely.io](https://docs.rely.io/)
+
+**Live Demo**: [demo.rely.io](https://demo.rely.io)
+
+## Details
+
+| Details |  |
+| --- | ----------- |
+| Does it require developers to have DevOps knowledge? | No |
+| Self-hosted: | SaaS but with the option to self-host integration engine and self-service agent |
+| Orchestrator | N/A. Rely.io integrates with any existing platform engineering automation, interfacing with any orchestrator chosen by the customer |
+| Integration Concept | API based |
+| Setup time first app | Minutes |
+| Source | Closed, integration enginee, integrations and self-service agent are open source |
+| Use Case | Scale-ups and Enterprise Setups |
+| Total Cost of Ownership | Rely.io's pricing model is seat-based and the details are available on [Rely.io website](https://www.rely.io/pricing) |
+| Adoption | Early but stable with customers, such as, Amplemarket, Rows, Feezai, etc...  |
+
+{{< button href="https://rely.io" target="_blank" >}}
+-> Rely.io
+{{< /button >}}  
+
+### **What is Rely.io?**
+
+[Rely.io](https://rely.io) is an **Internal Developer Portal** that aims to improve developer autonomy, reduce costs and ultimately increase developer productivity all while ensuring governance and standardization.
+
+Rely.io is opinionated enough so you can see value in minutes and highly flexible to support any use case and tech stack that customers might have.
+
+Starting with the Software Catalog, Rely.io covers microservices, teams, incidents, cloud resources, etc. To allow you to leverage your existing data model you can create custom assets and use Rely.io's REST API to import your data.
+
+Blueprints are a foundational concept for Rely.io. They are the representation of any resource, such as services, incidents, environment, cloud resources, etc. When you create an account with Rely.io you get several blueprints by default but as part or Rely.io's extensability features you can adapt the existing blueprints or create your own.
+
+Building on top of the Software Catalog and Blueprints Rely.io offers Scorecards that allow teams to track specific metrics and KPIs that are relevant to them. Scorecards are calculated dynamically and implement gamification features that create some healthy competition between teams.
+
+To improve developer autonomy and reduce ticket-ops, Rely.io provides Self-service capabilities to developers through its Self-service hub. By default, Rely.io offers certain Self-service actions by default but you can customize the Self-service actions and create your own.
+
+Lastly, Rely.io aims to be a central component to the day-to-day of developers. With that in mind, Rely.io, created developer homepages that you can customize to adapt to your daily tasks.
+
+**What is the mission and vision of Rely.io?**
+
+Every year, companies waste more than $1 trillion because developers spend up to 40% of their time working on mundane, non-code-producing work. [Rely.io](https://rely.io) has the goal to change that.
+
+Rely.io is building the next generation of intelligent tools and automation to supercharge developer productivity and reduce developer toil. To achieve that goal, Rely.io released an Internal Developer Portal that empowers engineering organizations to enhance visibility and engineering standards across their software ecosystem.
+
+### **A brief history of Rely.io**
+
+Rely.io was launched in 2022. Rely.io's founding team has over 10 years of hands-on DevEx expertise.
+
+### **Core features of Rely.io**
+
+* **Catalog** – Discorver and centralize all the relevant information about your services and resources, organized in service and team homepages.
+* **Measure** – From productivity and performance, to cost and reliability to ensure you have the complete picture in order to move fast and with complete confidence.
+* **Improve** – Engineering leaders define and track standards and KPIs for quality, production readiness, productivity, and more.
+* **Self-service** - Bake best practices into developer routines and automate their work away with boilerplate code and workflows.


### PR DESCRIPTION
This PR aims to add [Rely.io](https://rely.io) to the internal developer portal category.
- Added another option to the menu
- Created a new page for Rely.io

