### PR TITLE
Fix Markdown parsing in hint block via local shortcode override

### DIFF
--- a/layouts/shortcodes/hint.html
+++ b/layouts/shortcodes/hint.html
@@ -1,0 +1,3 @@
+<blockquote class="book-hint {{ .Get 0 }}">
+  {{ .InnerDeindent | markdownify | safeHTML }}
+</blockquote>


### PR DESCRIPTION
## Before: 
<img width="1356" alt="Screenshot 2025-06-07 at 13 20 51" src="https://github.com/user-attachments/assets/fbd90a2a-996b-40d6-820d-5b2885e6d3de" />
<img width="1103" alt="Screenshot 2025-06-07 at 13 21 45" src="https://github.com/user-attachments/assets/37343c02-4994-4dcd-8c6e-fd934e7752c1" />
## After: 
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/6fed3060-313b-4c55-898f-d7bdd961d1c3" />
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/b9eac668-d417-485d-a9c2-22889c2e0a06" />
