### PR TITLE
consultancies: Add Procedure

### DIFF
--- a/content/community/consultancies/_index.md
+++ b/content/community/consultancies/_index.md
@@ -29,6 +29,7 @@ There are a number of great DevOps consultancies out there that can help you to 
 | [NorthCode]({{< relref "northcode" >}})                             |
 | [One2N]({{< relref "one2n" >}})                                     |
 | [Platform Engineers]({{< relref "platform-engineers-io" >}})        |
+| [Procedure]({{< relref "procedure" >}})                             |
 | [Polarsquad]({{< relref "polarsquad" >}})                           |
 | [Tektit Consulting]({{< relref "tektit" >}})                        |
 | [Thoughtworks]({{< relref "thoughtworks" >}})                       |

--- a/content/community/consultancies/procedure.md
+++ b/content/community/consultancies/procedure.md
@@ -1,0 +1,29 @@
++++
+title="Procedure"
+url="/consultancies/procedure"
++++
+
+# Procedure
+
+Procedure is a software engineering consultancy specializing in cloud-native infrastructure, platform engineering, and .NET modernization. We help engineering teams design, build, and operate scalable platforms using Kubernetes, service meshes, and infrastructure-as-code.
+
+With offices in Mumbai and San Francisco, Procedure works with engineering leaders to reduce developer friction, improve deployment velocity, and build self-service platforms that scale. We are officially recognized partners for Prometheus and Istio, with deep expertise across the CNCF ecosystem.
+
+## Platform Engineering and Cloud-Native Services
+
+- Internal Developer Platform design and implementation
+- Kubernetes consulting, migration, and managed operations
+- Service mesh implementation (Istio, Linkerd, Envoy Gateway)
+- Observability stack setup (Prometheus, Grafana, Thanos, OpenTelemetry)
+- Infrastructure-as-code with Crossplane and Terraform
+- CI/CD pipeline design and GitOps automation
+- .NET to cloud-native modernization
+
+## Related Articles
+
+* [Node.js vs Python for Backend: When to Use What](https://procedure.tech/blogs/nodejs-vs-python-backend-comparison)
+* [Flutter vs React Native: How Engineering Teams Should Actually Decide](https://procedure.tech/blogs/flutter-vs-react-native-comparison)
+
+{{< button href="https://procedure.tech" target="_blank" >}}
+-> Procedure
+{{< /button >}}


### PR DESCRIPTION
Add Procedure to the consultancies directory.

Procedure (https://procedure.tech) is a software engineering consultancy
specializing in cloud-native infrastructure, platform engineering, and
.NET modernization. We help teams design, build, and operate Internal
Developer Platforms using Kubernetes, service meshes, and IaC.

Officially recognized partners for Prometheus and Istio, with deep
expertise across the CNCF ecosystem.

Changes:
- Added content/community/consultancies/procedure.md
- Added Procedure to the consultancies table in _index.md