### PR TITLE
Add Fortem to Platform Orchestrators

### DIFF
--- a/content/ecosystem/platform-tooling/platform-orchestrators/_index.md
+++ b/content/ecosystem/platform-tooling/platform-orchestrators/_index.md
@@ -20,6 +20,7 @@ Source: Thoughtworks, Technology Radar Vol 29, [Platform orchestration](https://
 | [Kratix]({{< relref "kratix" >}})           | Open-source platform framework for building composable internal developer platforms (IDPs)                            |
 | [KusionStack]({{< relref "kusionstack" >}}) | Open Tech Stack to build self-service, collaborative, reliable and sustainable Internal Developer Platform            |
 | [Massdriver]({{< relref "massdriver" >}})   | Streamlines the Design and Development of Internal Developer Platform (IDP) with Integrated Infrastructure Visibility |
+| [Fortem]({{< relref "fortem" >}})           | AI-native self-hosted Kubernetes Internal Developer Platform                                                          |
 
 
 

--- a/content/ecosystem/platform-tooling/platform-orchestrators/fortem.md
+++ b/content/ecosystem/platform-tooling/platform-orchestrators/fortem.md
@@ -1,0 +1,47 @@
++++
+title="Fortem"
+url="/platform-orchestrators/fortem"
++++
+
+# Fortem
+
+**Claim:** AI-native self-hosted Kubernetes Internal Developer Platform
+
+**Focus:** Fortem is a self-hosted Kubernetes IDP that installs as a single Helm chart and uses a Kubernetes Operator architecture to manage the full platform lifecycle. It targets platform and DevOps teams who need an on-premises or air-gapped IDP without vendor lock-in. Fortem adds AI-native capabilities directly to the platform layer: natural-language-to-manifest generation (NL-to-manifest), AIOps idle detection to reduce infrastructure waste, and an AI-assisted workflow for Helm releases, RBAC, and CRD management. The free Community tier makes it accessible to small teams and individuals exploring platform engineering.
+
+**Website:** [fortem.dev](https://fortem.dev/)
+
+### Details
+
+| Details                    |                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------- |
+| DevOps Knowledge Required? | Moderate (Kubernetes familiarity recommended)                                    |
+| Self-hosted:               | Yes                                                                              |
+| Orchestrator               | Kubernetes (Operator architecture)                                               |
+| Integration Concept        | Helm chart install; Kubernetes CRDs; native kubectl/RBAC integration             |
+| Setup time first app       | Under 30 minutes via Helm                                                        |
+| Source                     | Commercial (free Community tier)                                                 |
+| Use Case                   | Self-hosted / air-gapped Kubernetes platforms for teams of all sizes             |
+| Total Cost of Ownership    | Free Community tier; paid plans for larger teams (pricing at fortem.dev)         |
+| Adoption                   | Early-stage; growing community                                                   |
+
+{{< button href="https://fortem.dev" target="_blank" >}}
+-> Fortem
+{{< /button >}}
+
+### What is Fortem?
+
+Fortem is an AI-native Internal Developer Platform designed to run entirely inside a customer's own Kubernetes cluster. Unlike SaaS-first orchestrators, Fortem ships as a single Helm chart and leverages a Kubernetes Operator to manage platform resources declaratively via CRDs — meaning the platform itself follows the same GitOps patterns it enforces on application teams.
+
+The AI layer is embedded at the platform level rather than bolted on as a separate product. Platform engineers can describe desired Kubernetes resources in natural language and Fortem generates the corresponding manifests, validates them against cluster policy, and applies them through the standard Operator reconciliation loop. An AIOps idle-detection engine continuously monitors workload utilisation and surfaces recommendations to reclaim unused cluster capacity.
+
+Because Fortem runs in-cluster with zero outbound dependencies, it is suitable for regulated industries, air-gapped environments, and teams with strict data-residency requirements.
+
+## Core features of Fortem
+
+- **Single Helm chart install** — full platform stack deployable in one command; no external control plane required
+- **Kubernetes Operator architecture** — platform state managed via CRDs and reconciliation loops, consistent with GitOps practices
+- **NL-to-manifest generation** — natural language interface that produces and applies Kubernetes manifests (Deployments, Services, Ingresses, RBAC policies, Helm releases)
+- **AIOps idle detection** — continuous workload analysis to identify and reclaim wasted cluster resources
+- **Zero vendor lock-in** — all platform state lives in the customer's cluster; no proprietary state store or external API dependency
+- **Community tier** — free tier for individuals and small teams to self-host a production-grade IDP


### PR DESCRIPTION
## Summary

- Adds [Fortem](https://fortem.dev) as a new entry in the **Platform Orchestrators** category
- Creates `content/ecosystem/platform-tooling/platform-orchestrators/fortem.md` with a full tool profile
- Updates `_index.md` to include Fortem in the orchestrators summary table

## About Fortem

Fortem is an AI-native self-hosted Kubernetes Internal Developer Platform. It installs as a single Helm chart and uses a Kubernetes Operator architecture — meaning all platform state is managed via CRDs inside the customer's own cluster, with zero external dependencies or vendor lock-in.

Key differentiators vs. other entries in this category:
- **Fully self-hosted / air-gapped** — no SaaS control plane; suitable for regulated industries
- **AI-native at the platform layer** — NL-to-manifest generation, AIOps idle detection built in (not an add-on)
- **Single Helm chart install** — full stack in one command, under 30 minutes to first app
- **Free Community tier** available

**Website:** https://fortem.dev
**Category:** Platform Orchestrators (same as Humanitec, Kratix, KusionStack, Massdriver)